### PR TITLE
Change from "redengine" to "redmail" for import line

### DIFF
--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -7,7 +7,7 @@ Install the package from `Pypi <https://pypi.org/project/redmail/>`_:
 
 .. code-block:: console
 
-    pip install redengine
+    pip install redmail
 
 .. _configure:
 


### PR DESCRIPTION
A small correction - the docs refer to importing "redengine" in the **Getting Started** page rather than "redmail". Unless I've misunderstood something, I think it should be importing "redmail" based on the further code examples on the page.