### PR TITLE
ENH: Outlook sender

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,7 +77,7 @@ There are also other reasons to use Red Mail:
 - :ref:`You can render nicer tables to the body <embedding-tables>`
 - :ref:`It has Jinja support <jinja-support>`
 - :ref:`You can reuse your HTML templates <templating>`
-- :ref:`Gmail pre-configured <config-gmail>`
+- :ref:`Gmail <config-gmail>` and :ref:`Outlook <config-outlook>` pre-configured
 - :ref:`Send with cc and bcc <send-cc-bcc>`
 - :ref:`Change the email protocol to what you need <config-smtp>`
 - And it is well tested and documented

--- a/docs/tutorials/config.rst
+++ b/docs/tutorials/config.rst
@@ -36,6 +36,15 @@ and then you can use the sender:
     to something else than what was used to log in. Therefore, changing 
     the ``sender`` argument often has no effect.
 
+.. note::
+
+    By default, Red Mail uses STARTTLS which should be suitable for majority of cases
+    and the pre-configured ports should support this. However, in some cases you may 
+    need to use other protocol and port. In such case, you may override the ``sender.port`` 
+    and ``sender.cls_smtp`` attributes. Read more about configuring different protocols 
+    from :ref:`config-smtp`.
+
+
 .. _config-gmail:
 
 Gmail

--- a/docs/tutorials/config.rst
+++ b/docs/tutorials/config.rst
@@ -2,14 +2,54 @@
 Configuring for Different Providers
 ===================================
 
+Sending emails from different email providers is easy.
+If you have your own SMTP server, you just need to 
+set the host address, port and possibly the credentials.
+There are also pre-configured sender instances for 
+common email providers:
+
+=================== =================== ================== ====
+Provider            Sender instance     Host               Port
+=================== =================== ================== ====
+Gmail (Google)      ``redmail.gmail``   smtp.gmail.com     587
+Outlook (Microsoft) ``redmail.outlook`` smtp.office365.com 587          
+=================== =================== ================== ====
+
+To use them, you may need to configure the account (see below)
+and then you can use the sender:
+
+.. code-block:: python
+
+    from redmail import outlook
+    outlook.user_name = 'example@hotmail.com'
+    outlook.password = '<YOUR PASSWORD>'
+
+    outlook.send(
+        subject="Example email",
+        receivers=['you@example.com'],
+        text="Hi, this is an email."
+    )
+
+.. note::
+
+    Often the email providers don't allow changing the sender address
+    to something else than what was used to log in. Therefore, changing 
+    the ``sender`` argument often has no effect.
+
 .. _config-gmail:
 
 Gmail
 -----
 
-You need to make an application password `see this Google's answer <https://support.google.com/accounts/answer/185833>`_.
-You may also need to set up `2-step verification <https://support.google.com/accounts/answer/185839>`_ in order to
-be able to create an application password. Don't worry, those are easy things to configure.
+In order to send emails using Gmail, you need to:
+
+- Set up `2-step verification <https://support.google.com/accounts/answer/185839>`_ (if not already)
+- Generate `an App password <https://support.google.com/accounts/answer/185833>`_:
+
+    - Go to your `Google account <https://myaccount.google.com/>`_
+    - Go to *Security*
+    - Go to *App passwords*
+    - Generate a new one (you may use custom app and give it a custom name)
 
 When you have your application password you can use Red Mail's gmail object that has the Gmail
 server pre-configured:
@@ -23,15 +63,28 @@ server pre-configured:
     # And then you can send emails
     gmail.send(
         subject="Example email",
-        receivers=['example@gmail.com']
+        receivers=['you@example.com'],
         text="Hi, this is an email."
     )
 
-.. note::
 
-    You can only send emails using your Gmail email address. Changing ``sender`` has no effect.
+.. _config-outlook:
 
-.. note::
+Outlook
+-------
 
-    ``gmail`` is actually nothing more than an instance of :class:`redmail.EmailSender`
-    with ``smtp.gmail.com`` as the host and ``587`` as the port.
+You may also send emails from MS Outlook. To do so, you just need to have a Microsoft
+account. There is a pre-configured sender which you may use:
+
+.. code-block:: python
+
+    from redmail import outlook
+    outlook.user_name = 'example@hotmail.com'
+    outlook.password = '<YOUR PASSWORD>'
+
+    # And then you can send emails
+    outlook.send(
+        subject="Example email",
+        receivers=['you@example.com'],
+        text="Hi, this is an email."
+    )

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -40,6 +40,11 @@ There are guides to set up the following email providers:
 - :ref:`config-gmail`
 - :ref:`config-outlook`
 
+.. note::
+
+    By default, Red Mail uses **STARTTLS** as the protocol.
+    This is suitable for majority of cases but if you need
+    to use **SSL**, **TLS** or other protocols, see :ref:`config-smtp`.
 
 Sending Emails
 --------------

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -35,8 +35,10 @@ You can configure your sender by:
        port='<SMTP PORT>',
    )
 
-Alternatively, there is a pre-configured sender for Gmail. 
-Please see :ref:`how to configure Gmail <config-gmail>` for more.
+There are guides to set up the following email providers:
+
+- :ref:`config-gmail`
+- :ref:`config-outlook`
 
 
 Sending Emails

--- a/redmail/__init__.py
+++ b/redmail/__init__.py
@@ -1,3 +1,3 @@
-from .email import EmailSender, send_email, gmail
+from .email import EmailSender, send_email, gmail, outlook
 from . import _version
 __version__ = _version.get_versions()['version']

--- a/redmail/email/__init__.py
+++ b/redmail/email/__init__.py
@@ -5,6 +5,11 @@ gmail = EmailSender(
     port=587,
 )
 
+outlook = EmailSender(
+    host='smtp.office365.com',
+    port=587,
+)
+
 def send_email(*args, host:str, port:int, user_name:str=None, password:str=None, **kwargs):
     """Send email
 


### PR DESCRIPTION
This PR introduces ``redmail.outlook`` pre-configured sender and also includes docs about sending emails from Outlook. In addition, there are some improvements in Gmail configuration docs.