### PR TITLE
add: support for sending multiple emails

### DIFF
--- a/docs/tutorials/sending.rst
+++ b/docs/tutorials/sending.rst
@@ -117,3 +117,49 @@ You can also alias the sender and receivers:
 Alias is an alternative text that is displayed instead of 
 the actual email addresses. The receivers can still get 
 the addresses though.
+
+.. _send-multi:
+
+Sending Multiple Emails
+-----------------------
+
+Normally Red Mail opens and closes the connection to the SMTP
+server when sending each email. If you are sending large amount
+of emails it may be beneficial to leave the connection open:
+
+.. code-block:: python
+
+    with email:
+        email.send(
+            subject='email subject',
+            sender="me@example.com",
+            receivers=['you@example.com']
+        )
+
+        email.send(
+            subject='email subject',
+            sender="me@example.com",
+            receivers=['they@example.com']
+        )
+        ...
+
+Alternatively, you may use the ``connect`` and ``close``
+methods:
+
+.. code-block:: python
+
+    try:
+        email.connect()
+        email.send(
+            subject='email subject',
+            sender="me@example.com",
+            receivers=['you@example.com']
+        )
+        email.send(
+            subject='email subject',
+            sender="me@example.com",
+            receivers=['they@example.com']
+        )
+        ...
+    finally:
+        email.close()

--- a/redmail/email/sender.py
+++ b/redmail/email/sender.py
@@ -399,8 +399,6 @@ class EmailSender:
 
     def get_server(self) -> smtplib.SMTP:
         "Connect and get the SMTP Server"
-        if self.connection is not None:
-            return self.connection
         user = self.user_name
         password = self.password
         

--- a/redmail/test/email/test_send.py
+++ b/redmail/test/email/test_send.py
@@ -47,6 +47,12 @@ def test_send_multi():
         )
         assert isinstance(msg, EmailMessage)
         assert email.connection is not None
+        msg = email.send(
+            subject="An example",
+            receivers=['koli.mikael@example.com']
+        )
+        assert isinstance(msg, EmailMessage)
+        assert email.connection is not None
     assert email.connection is None
 
 def test_send_function():

--- a/redmail/test/email/test_send.py
+++ b/redmail/test/email/test_send.py
@@ -26,12 +26,28 @@ class MockServer:
 
 def test_send():
     email = EmailSender(host="localhost", port=0, cls_smtp=MockServer)
-    # This should fail but we test everything else goes through
+    assert email.connection is None
+
     msg = email.send(
         subject="An example",
         receivers=['koli.mikael@example.com']
     )
     assert isinstance(msg, EmailMessage)
+    assert email.connection is None
+
+def test_send_multi():
+    email = EmailSender(host="localhost", port=0, cls_smtp=MockServer)
+
+    assert email.connection is None
+    with email:
+        assert email.connection is not None
+        msg = email.send(
+            subject="An example",
+            receivers=['koli.mikael@example.com']
+        )
+        assert isinstance(msg, EmailMessage)
+        assert email.connection is not None
+    assert email.connection is None
 
 def test_send_function():
     # This should fail but we test everything else goes through


### PR DESCRIPTION
Now it should be possible to open the connection and send multiple emails per email session.

**NOTE:** If someone has subclassed the ``EmailSender`` and overridden the ``connect`` method, this may break.
The possibility of this is very small though as the method is not well documented.