### PR TITLE
setup.py: add MIT license to classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     classifiers=[
         "Topic :: Communications :: Email",
         "Operating System :: OS Independent",
+        "License :: OSI Approved :: MIT License",
 
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
The project contains an MIT license in the LICENSE file, but this is not
reflected in the package classifiers.

I'd like to consider using red-mail in a project, but the automation requires the license to be listed in the classifiers.  Please consider merging.