### PR TITLE
Fix embedded image cid for named senders with a 'from' address like 'Sender <noreply@sender.com>'

### DIFF
--- a/redmail/email/body.py
+++ b/redmail/email/body.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from redmail.utils import is_bytes
 from redmail.utils import import_from_string
 
-from email.utils import make_msgid
+from email.utils import make_msgid, parseaddr
 
 from jinja2.environment import Template, Environment
 
@@ -109,7 +109,7 @@ class HTMLBody(Body):
             jinja_params : dict
                 Extra Jinja parameters for the HTML.
         """
-        domain = msg["from"].split("@")[-1] if self.domain is None else self.domain
+        domain = parseaddr(msg["from"])[1].split("@")[-1] if self.domain is None else self.domain
         html, cids = self.render(
             html, 
             images=images,


### PR DESCRIPTION
I was struggeling with embedding an image in an html mail body. The picture was attached however it didn't show up in Outlook. 

The issue was caused by the sender address which was something like 'AnyFancyName <email@address.com>'. To be precise the issue is caused by the '>' at the end of the string which survives with your current split logic and causes the cid to have two '>' characters at the end.

I would suggest to use parseaddr function from email.utils to get the raw email address from the msg['from'] field.