### PR TITLE
BUG: Email structure

### DIFF
--- a/ci/test_send.py
+++ b/ci/test_send.py
@@ -17,18 +17,18 @@ email = EmailSender(
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-def send():
+def send_empty():
     msg = email.send(
         sender=os.environ['EMAIL_SENDER'],
         receivers=os.environ['EMAIL_RECEIVERS'].split(","),
-        subject="An example",
+        subject="Empty email",
     )
 
 def send_text():
     msg = email.send(
         sender=os.environ['EMAIL_SENDER'],
         receivers=os.environ['EMAIL_RECEIVERS'].split(","),
-        subject="An example",
+        subject="Email with text",
         text="Hi, this is an example email.",
     )
 
@@ -36,17 +36,17 @@ def send_html():
     msg = email.send(
         sender=os.environ['EMAIL_SENDER'],
         receivers=os.environ['EMAIL_RECEIVERS'].split(","),
-        subject="An example",
-        html="<h1>Hi,</h1><p>this is an example email.</p>",
+        subject="Email with HTML",
+        html="<h2>This is HTML.</h2>",
     )
 
 def send_test_and_html():
     msg = email.send(
         sender=os.environ['EMAIL_SENDER'],
         receivers=os.environ['EMAIL_RECEIVERS'].split(","),
-        subject="An example",
-        text="<h1>Hi,</h1><p>this is an example email.</p>",
-        html="<h1>Hi,</h1><p>this is an example email.</p>",
+        subject="Email with text and HTML",
+        text="This is text (with HTML).",
+        html="<h2>This is HTML (with text).</h2>",
     )
 
 
@@ -54,7 +54,7 @@ def send_attachments():
     msg = email.send(
         sender=os.environ['EMAIL_SENDER'],
         receivers=os.environ['EMAIL_RECEIVERS'].split(","),
-        subject="An attachment",
+        subject="Email with attachment",
         attachments={"a_file.html": (Path(__file__).parent / "file.html")}
     )
 
@@ -62,8 +62,8 @@ def send_attachments_with_text():
     msg = email.send(
         sender=os.environ['EMAIL_SENDER'],
         receivers=os.environ['EMAIL_RECEIVERS'].split(","),
-        subject="An attachment with text body",
-        text="Hi, this contains an attachment.",
+        subject="Email with attachment and text",
+        text="This contains an attachment.",
         attachments={"a_file.html": (Path(__file__).parent / "file.html")}
     )
 
@@ -71,18 +71,33 @@ def send_attachments_with_html():
     msg = email.send(
         sender=os.environ['EMAIL_SENDER'],
         receivers=os.environ['EMAIL_RECEIVERS'].split(","),
-        subject="An attachment with HTML body",
-        html="<h1>Hi, this contains an attachment.</h1>",
+        subject="Email with attachment and HTML",
+        html="<h1>This contains an attachment.</h1>",
         attachments={"a_file.html": (Path(__file__).parent / "file.html")}
     )
 
-def send_attachments_with_text_and_html():
+def send_attachments_with_html_and_image():
     msg = email.send(
         sender=os.environ['EMAIL_SENDER'],
         receivers=os.environ['EMAIL_RECEIVERS'].split(","),
-        subject="An attachment with text and HTML body",
-        text="Hi, this contains an attachment",
-        html="<h1>Hi, this contains an attachment.</h1>",
+        subject="Email with attachment, HTML and inline image",
+        html="<h1>This contains an attachment and image.</h1>{{ path_image }}",
+        body_images={
+            "path_image": Path(__file__).parent.parent / "docs/imgs/email_emb_img.png",
+        },
+        attachments={"a_file.html": (Path(__file__).parent / "file.html")}
+    )
+
+def send_full_features():
+    msg = email.send(
+        sender=os.environ['EMAIL_SENDER'],
+        receivers=os.environ['EMAIL_RECEIVERS'].split(","),
+        subject="Email with full features",
+        text="Hi, this contains an attachment and image.",
+        html="<h1>This contains text, HTML, an attachment and inline image.</h1>{{ path_image }}",
+        body_images={
+            "path_image": Path(__file__).parent.parent / "docs/imgs/email_emb_img.png",
+        },
         attachments={"a_file.html": (Path(__file__).parent / "file.html")}
     )
 
@@ -194,15 +209,17 @@ def log_simple():
 
 
 if __name__ == "__main__":
-    fn_bodies = [send, send_text, send_html, send_test_and_html]
-    fn_attachments = [send_attachments, send_attachments_with_text, send_attachments_with_html, send_attachments_with_text_and_html]
+    fn_bodies = [send_empty, send_text, send_html, send_test_and_html, send_full_features]
+    fn_attachments = [send_attachments, send_attachments_with_text, send_attachments_with_html]
     fn_log = [log_simple, log_multi]
 
     funcs = {
         "minimal": fn_bodies[0],
+        "bodies": fn_bodies,
         "full": fn_bodies + fn_attachments + fn_log,
         "logging": fn_log,
     }[os.environ.get("EMAIL_FUNCS", "full")]
     for func in funcs:
+        print("Running:", func.__name__)
         time.sleep(1)
         func()

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -21,3 +21,71 @@ Logging Classes
 .. autoclass:: redmail.EmailHandler
 
 .. autoclass:: redmail.MultiEmailHandler
+
+
+.. _email_structure:
+
+Email Strucure (MIME)
+---------------------
+
+This section covers how Red Mail structures emails with MIME parts.
+You may need this information if you are creating unit tests or 
+if you face problems with rendering your emails by your email provider.
+
+Empty Email
+^^^^^^^^^^^
+
+Empty email has no MIME parts attached. It only has the headers.
+
+
+Email with a text body
+^^^^^^^^^^^^^^^^^^^^^^
+
+* text/plain
+
+
+Email with an HTML body
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* multipart/mixed
+
+    * multipart/alternative
+
+        * text/html
+
+
+Email with an HTML body and inline JPG image
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* multipart/mixed
+
+    * multipart/alternative
+
+        * multipart/related
+
+            * text/html
+            * image/jpg
+
+
+Email with an attachment
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* multipart/mixed
+
+    * application/octet-stream
+
+
+Email with all elements
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* multipart/mixed
+
+    * multipart/alternative
+
+        * text/plain
+        * multipart/related
+
+            * text/html
+            * image/jpg
+
+    * application/octet-stream

--- a/docs/tutorials/testing.rst
+++ b/docs/tutorials/testing.rst
@@ -12,7 +12,10 @@ with unit tests. There are several ways to do this.
 
     Red Mail extends :stdlib:`email.message.EmailMessage <email.message.html#email.message.EmailMessage>`
     from standard library. You may use its attributes and
-    methods for testing the contents of your messages.
+    methods for testing the contents of your messages. 
+    
+    See :ref:`email_structure` for how Red Mail's
+    emails are structured.
 
 Using get_message
 -----------------

--- a/redmail/email/attachment.py
+++ b/redmail/email/attachment.py
@@ -18,12 +18,6 @@ class Attachments:
         self.encoding = encoding
 
     def attach(self, msg:EmailMessage):
-        if msg.get_content_type() == "text/plain":
-            # We need to change the content type
-            # This occurs if no body is defined or only text is defined
-            # The content type is therefore changed to multipart/mixed
-            # See issue #23
-            msg.make_mixed()
         for part in self._get_parts():
             msg.attach(part)
 

--- a/redmail/email/sender.py
+++ b/redmail/email/sender.py
@@ -338,6 +338,18 @@ class EmailSender:
                 tables=body_tables,
                 jinja_params=self.get_html_params(extra=body_params, sender=sender)
             )
+
+        # Change the structure to multipart/mixed if possible.
+        # This seems to be the most versatile and most unproblematic top level content-type
+        # as otherwise content may be missing or it may be misrendered.
+        # See: https://stackoverflow.com/a/23853079/13696660
+        # See issues: #23, #37
+        try:
+            msg.make_mixed()
+        except ValueError:
+            # Cannot convert to mixed
+            pass
+        
         if attachments:
             att = Attachments(attachments, encoding=self.attachment_encoding)
             att.attach(msg)

--- a/redmail/email/sender.py
+++ b/redmail/email/sender.py
@@ -394,11 +394,7 @@ class EmailSender:
             # as otherwise content may be missing or it may be misrendered.
             # See: https://stackoverflow.com/a/23853079/13696660
             # See issues: #23, #37
-            try:
-                msg.make_mixed()
-            except ValueError:
-                # Cannot convert to mixed
-                pass
+            msg.make_mixed()
 
     def send_message(self, msg:EmailMessage):
         "Send the created message"

--- a/redmail/test/email/test_body.py
+++ b/redmail/test/email/test_body.py
@@ -2,93 +2,123 @@ from redmail import EmailSender
 
 import pytest
 
-from convert import remove_extra_lines
+from convert import remove_extra_lines, payloads_to_dict
 from getpass import getpass, getuser
 from platform import node
 
 from convert import remove_email_extra
 
 def test_text_message():
-    text = "Hi, nice to meet you."
 
     sender = EmailSender(host=None, port=1234)
     msg = sender.get_message(
         sender="me@gmail.com",
         receivers="you@gmail.com",
         subject="Some news",
-        text=text,
+        text="Hi, nice to meet you.",
     )
-    payload = msg.get_payload()
+
+    # Validate structure
+    assert payloads_to_dict(msg) == {
+        'multipart/mixed': {
+            'text/plain': 'Hi, nice to meet you.\n',
+        }
+    }
+    assert msg.get_content_type() == "multipart/mixed"
+
+    text = msg.get_payload()[0]
+
     expected_headers = {
         'from': 'me@gmail.com', 
         'subject': 'Some news', 
         'to': 'you@gmail.com', 
         'MIME-Version': '1.0', 
-        'Content-Type': 'text/plain; charset="utf-8"',
-        'Content-Transfer-Encoding': '7bit',
+        'Content-Type': 'multipart/mixed',
+        #'Content-Transfer-Encoding': '7bit',
     }
 
-    assert "text/plain" == msg.get_content_type()
-    assert text + "\n" == payload
+    assert "text/plain" == text.get_content_type()
+    assert "Hi, nice to meet you.\n" == text.get_payload()
 
     # Test receivers etc.
     headers = dict(msg.items())
     assert expected_headers == headers
 
 def test_html_message():
-    html = "<h3>Hi,</h3><p>Nice to meet you</p>"
 
     sender = EmailSender(host=None, port=1234)
     msg = sender.get_message(
         sender="me@gmail.com",
         receivers="you@gmail.com",
         subject="Some news",
-        html=html,
+        html="<h3>Hi,</h3><p>Nice to meet you</p>",
     )
-    payload = msg.get_payload()
+
+    # Validate structure
+    assert payloads_to_dict(msg) == {
+        'multipart/mixed': {
+            'multipart/alternative': {
+                'text/html': '<h3>Hi,</h3><p>Nice to meet you</p>\n',
+            }
+        }
+    }
+    assert msg.get_content_type() == "multipart/mixed"
+
+    alternative = msg.get_payload()[0]
+    html = alternative.get_payload()[0]
     expected_headers = {
         'from': 'me@gmail.com', 
         'subject': 'Some news', 
         'to': 'you@gmail.com', 
         #'MIME-Version': '1.0', 
-        'Content-Type': 'multipart/alternative'
+        'Content-Type': 'multipart/mixed'
     }
 
-    assert "multipart/alternative" == msg.get_content_type()
-    assert html + "\n" == payload[0].get_content()
+    assert "<h3>Hi,</h3><p>Nice to meet you</p>\n" == html.get_content()
 
     # Test receivers etc.
     headers = dict(msg.items())
     assert expected_headers == headers
 
 def test_text_and_html_message():
-    html = "<h3>Hi,</h3><p>nice to meet you.</p>"
-    text = "Hi, nice to meet you."
 
     sender = EmailSender(host=None, port=1234)
     msg = sender.get_message(
         sender="me@gmail.com",
         receivers="you@gmail.com",
         subject="Some news",
-        html=html,
-        text=text,
+        html="<h3>Hi,</h3><p>nice to meet you.</p>",
+        text="Hi, nice to meet you.",
     )
-    payload = msg.get_payload()
+
+    # Validate structure
+    assert payloads_to_dict(msg) == {
+        'multipart/mixed': {
+            'multipart/alternative': {
+                'text/plain': 'Hi, nice to meet you.\n',
+                'text/html': '<h3>Hi,</h3><p>nice to meet you.</p>\n',
+            }
+        }
+    }
+
+    alternative = msg.get_payload()[0]
+    text, html = alternative.get_payload()
+
     expected_headers = {
         'from': 'me@gmail.com', 
         'subject': 'Some news', 
         'to': 'you@gmail.com', 
         'MIME-Version': '1.0', 
-        'Content-Type': 'multipart/alternative'
+        'Content-Type': 'multipart/mixed'
     }
 
-    assert "multipart/alternative" == msg.get_content_type()
+    assert "multipart/mixed" == msg.get_content_type()
 
-    assert "text/plain" == payload[0].get_content_type()
-    assert text + "\n" == payload[0].get_content()
+    assert "text/plain" == text.get_content_type()
+    assert "Hi, nice to meet you.\n" == text.get_content()
 
-    assert "text/html" == payload[1].get_content_type()
-    assert html + "\n" == payload[1].get_content()
+    assert "text/html" == html.get_content_type()
+    assert "<h3>Hi,</h3><p>nice to meet you.</p>\n" == html.get_content()
 
     # Test receivers etc.
     headers = dict(msg.items())
@@ -130,10 +160,23 @@ def test_with_jinja_params(html, text, extra, expected_html, expected_text):
         body_params=extra
     )
     
-    assert "multipart/alternative" == msg.get_content_type()
+    # Validate structure
+    structure = payloads_to_dict(msg)
+    assert structure == {
+        'multipart/mixed': {
+            'multipart/alternative': {
+                'text/plain': structure["multipart/mixed"]["multipart/alternative"]["text/plain"],
+                'text/html': structure["multipart/mixed"]["multipart/alternative"]["text/html"],
+            }
+        }
+    }
 
-    text = remove_email_extra(msg.get_payload()[0].get_payload())
-    html = remove_email_extra(msg.get_payload()[1].get_payload())
+    assert "multipart/mixed" == msg.get_content_type()
+    alternative = msg.get_payload()[0]
+    text_part, html_part = alternative.get_payload()
+    
+    text = remove_email_extra(text_part.get_payload())
+    html = remove_email_extra(html_part.get_payload())
 
     assert expected_html == html
     assert expected_text == text
@@ -150,8 +193,12 @@ def test_with_error():
             text="Error occurred \n{{ error }}",
             html="<h1>Error occurred: </h1>{{ error }}",
         )
-    text = remove_email_extra(msg.get_payload()[0].get_payload())
-    html = remove_email_extra(msg.get_payload()[1].get_payload())
+
+    alternative = msg.get_payload()[0]
+    text_part, html_part = alternative.get_payload()
+
+    text = remove_email_extra(text_part.get_payload())
+    html = remove_email_extra(html_part.get_payload())
 
     assert text.startswith('Error occurred\nTraceback (most recent call last):\n  File "')
     assert text.endswith(', in test_with_error\n    raise RuntimeError("Deliberate failure")\nRuntimeError: Deliberate failure\n')
@@ -169,15 +216,15 @@ def test_set_defaults():
         'from': 'me@gmail.com', 
         'to': 'you@gmail.com, they@gmail.com', 
         'subject': 'Some email', 
-        'Content-Type': 'text/plain; charset="utf-8"', 
-        'Content-Transfer-Encoding': '7bit', 
+        'Content-Type': 'multipart/mixed', 
+        #'Content-Transfer-Encoding': '7bit', 
         'MIME-Version': '1.0'
     } == dict(msg.items())
 
 def test_cc_bcc():
     email = EmailSender(host=None, port=1234)
     msg = email.get_message(sender="me@example.com", subject="Something", cc=['you@example.com'], bcc=['he@example.com', 'she@example.com'])
-    assert dict(msg.items()) == {'from': 'me@example.com', 'subject': 'Something', 'cc': 'you@example.com', 'bcc': 'he@example.com, she@example.com'}
+    assert dict(msg.items()) == {'from': 'me@example.com', 'subject': 'Something', 'cc': 'you@example.com', 'bcc': 'he@example.com, she@example.com', 'Content-Type': 'multipart/mixed'}
 
 def test_missing_subject():
     email = EmailSender(host=None, port=1234)
@@ -205,5 +252,5 @@ def test_no_table_templates():
         'subject': 'Some news', 
         'to': 'you@gmail.com', 
         'MIME-Version': '1.0', 
-        'Content-Type': 'multipart/alternative',
+        'Content-Type': 'multipart/mixed',
     }

--- a/redmail/test/email/test_cookbook.py
+++ b/redmail/test/email/test_cookbook.py
@@ -41,5 +41,6 @@ def test_distributions():
         'from': 'me@example.com', 
         'subject': 'Some email', 
         'to': 'me@example.com, you@example.com', 
-        'cc': 'he@example.com, she@example.com', 
+        'cc': 'he@example.com, she@example.com',
+        'Content-Type': 'multipart/mixed'
     }

--- a/redmail/test/email/test_cookbook.py
+++ b/redmail/test/email/test_cookbook.py
@@ -1,6 +1,9 @@
 
 from typing import Union
+from textwrap import dedent
 from redmail import EmailSender
+
+from convert import remove_email_content_id
 
 def test_distributions():
     class DistrSender(EmailSender):
@@ -37,10 +40,10 @@ def test_distributions():
         cc="group2",
         subject="Some email",
     )
-    assert dict(msg.items()) == {
-        'from': 'me@example.com', 
-        'subject': 'Some email', 
-        'to': 'me@example.com, you@example.com', 
-        'cc': 'he@example.com, she@example.com',
-        'Content-Type': 'multipart/mixed'
-    }
+    assert remove_email_content_id(str(msg)) == dedent("""
+    from: me@example.com
+    subject: Some email
+    to: me@example.com, you@example.com
+    cc: he@example.com, she@example.com
+
+    """)[1:]

--- a/redmail/test/email/test_structure.py
+++ b/redmail/test/email/test_structure.py
@@ -1,0 +1,202 @@
+from redmail import EmailSender
+
+import pytest
+
+from convert import remove_extra_lines, payloads_to_dict
+from getpass import getpass, getuser
+from platform import node
+import base64, re
+
+from convert import remove_email_extra
+
+def test_empty():
+
+    sender = EmailSender(host=None, port=1234)
+    msg = sender.get_message(
+        sender="me@example.com",
+        receivers="you@example.com",
+        subject="An example",
+    )
+    structure = payloads_to_dict(msg)
+    assert structure == {
+        "multipart/mixed": {}
+    }
+
+def test_text():
+
+    sender = EmailSender(host=None, port=1234)
+    msg = sender.get_message(
+        sender="me@example.com",
+        receivers="you@example.com",
+        subject="An example",
+        text="Text content",
+    )
+    structure = payloads_to_dict(msg)
+    assert structure == {
+        "multipart/mixed": {
+            'text/plain': 'Text content\n'
+        }
+    }
+
+def test_html():
+    sender = EmailSender(host=None, port=1234)
+    msg = sender.get_message(
+        sender="me@example.com",
+        receivers="you@example.com",
+        subject="An example",
+        html="<h1>HTML content</h1>",
+    )
+    structure = payloads_to_dict(msg)
+    assert structure == {
+        "multipart/mixed": {
+            'multipart/alternative': {
+                'text/html': '<h1>HTML content</h1>\n'
+            }
+        }
+    }
+
+def test_text_and_html():
+    sender = EmailSender(host=None, port=1234)
+    msg = sender.get_message(
+        sender="me@example.com",
+        receivers="you@example.com",
+        subject="An example",
+        text="Text content",
+        html="<h1>HTML content</h1>",
+    )
+    structure = payloads_to_dict(msg)
+    assert structure == {
+        "multipart/mixed": {
+            'multipart/alternative': {
+                'text/plain': 'Text content\n',
+                'text/html': '<h1>HTML content</h1>\n'
+            }
+        }
+    }
+
+def test_attachment():
+    sender = EmailSender(host=None, port=1234)
+    msg = sender.get_message(
+        sender="me@example.com",
+        receivers="you@example.com",
+        subject="An example",
+        attachments={'data.txt': "Some content"}
+    )
+    structure = payloads_to_dict(msg)
+    assert structure == {
+        "multipart/mixed": {
+            'application/octet-stream': 'U29tZSBjb250ZW50\n'
+        }
+    }
+
+def test_html_inline():
+    img_data = '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcGBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5rooor8DP9oD/2Q=='
+    img_bytes = base64.b64decode(img_data)
+
+    sender = EmailSender(host=None, port=1234)
+    msg = sender.get_message(
+        sender="me@example.com",
+        receivers="you@example.com",
+        subject="An example",
+        html='<p>HTML content</p> \n{{ my_image }}',
+        body_images={
+            "my_image": {
+                "content": img_bytes,
+                'subtype': 'jpg'
+            }
+        },
+    )
+
+    structure = payloads_to_dict(msg)
+    cid = re.search('(?<=cid:).+(?=@)', structure["multipart/mixed"]["multipart/alternative"]["multipart/related"]["text/html"]).group()
+    assert structure == {
+        "multipart/mixed": {
+            "multipart/alternative": {
+                "multipart/related": {
+                    'text/html': f'<p>HTML content</p> \n<img src="cid:{cid}@example.com">\n',
+                    'image/jpg': '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcG\nBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwM\nDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIA\nAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA\nAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3\nODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm\np6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA\nAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx\nBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK\nU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3\nuLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5rooo\nr8DP9oD/2Q==\n',
+                }
+            },
+        }
+    }
+
+def test_text_html_inline_attachment():
+    img_data = '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcGBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5rooor8DP9oD/2Q=='
+    img_bytes = base64.b64decode(img_data)
+
+    sender = EmailSender(host=None, port=1234)
+    msg = sender.get_message(
+        sender="me@example.com",
+        receivers="you@example.com",
+        subject="An example",
+        text="Text content",
+        html='<p>HTML content</p> \n{{ my_image }}',
+        body_images={
+            "my_image": {
+                "content": img_bytes,
+                'subtype': 'jpg'
+            }
+        },
+        attachments={'data.txt': "Some content"},
+    )
+
+    structure = payloads_to_dict(msg)
+    cid = re.search('(?<=cid:).+(?=@)', structure["multipart/mixed"]["multipart/alternative"]["multipart/related"]["text/html"]).group()
+    assert structure == {
+        "multipart/mixed": {
+            "multipart/alternative": {
+                'text/plain': 'Text content\n',
+                "multipart/related": {
+                    'text/html': f'<p>HTML content</p> \n<img src="cid:{cid}@example.com">\n',
+                    'image/jpg': '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcG\nBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwM\nDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIA\nAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA\nAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3\nODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm\np6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA\nAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx\nBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK\nU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3\nuLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5rooo\nr8DP9oD/2Q==\n',
+                }
+            },
+            # Attachments
+            'application/octet-stream': 'U29tZSBjb250ZW50\n'
+        }
+    }
+
+def test_text_html_inline_attachment_multiple():
+    img_data = '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcGBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5rooor8DP9oD/2Q=='
+    img_bytes = base64.b64decode(img_data)
+
+    sender = EmailSender(host=None, port=1234)
+    msg = sender.get_message(
+        sender="me@example.com",
+        receivers="you@example.com",
+        subject="An example",
+        text="Text content",
+        html='<p>HTML content</p> \n{{ my_image_1 }}\n{{ my_image_2 }}',
+        body_images={
+            "my_image_1": {
+                "content": img_bytes,
+                'subtype': 'jpg'
+            },
+            "my_image_2": {
+                "content": img_bytes,
+                'subtype': 'jpg'
+            },
+        },
+        attachments={
+            'data_1.txt': "Some content 1",
+            "data_2.txt": "Some content 2",
+        },
+    )
+
+    structure = payloads_to_dict(msg)
+    cid_1, cid_2 = re.findall('(?<=cid:).+(?=@)', structure["multipart/mixed"]["multipart/alternative"]["multipart/related"]["text/html"])
+    assert structure == {
+        "multipart/mixed": {
+            "multipart/alternative": {
+                'text/plain': 'Text content\n',
+                "multipart/related": {
+                    'text/html': f'<p>HTML content</p> \n<img src="cid:{cid_1}@example.com">\n<img src="cid:{cid_2}@example.com">\n',
+                    'image/jpg':   '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcG\nBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwM\nDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIA\nAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA\nAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3\nODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm\np6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA\nAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx\nBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK\nU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3\nuLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5rooo\nr8DP9oD/2Q==\n',
+                    'image/jpg_1': '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcG\nBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwM\nDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIA\nAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA\nAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3\nODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm\np6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA\nAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx\nBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK\nU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3\nuLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5rooo\nr8DP9oD/2Q==\n',
+                }
+            },
+            # Attachments
+            'application/octet-stream': 'U29tZSBjb250ZW50IDE=\n',
+            'application/octet-stream_1': 'U29tZSBjb250ZW50IDI=\n'
+        }
+    }

--- a/redmail/test/email/test_structure.py
+++ b/redmail/test/email/test_structure.py
@@ -18,9 +18,7 @@ def test_empty():
         subject="An example",
     )
     structure = payloads_to_dict(msg)
-    assert structure == {
-        "multipart/mixed": {}
-    }
+    assert structure == {}
 
 def test_text():
 
@@ -33,9 +31,7 @@ def test_text():
     )
     structure = payloads_to_dict(msg)
     assert structure == {
-        "multipart/mixed": {
-            'text/plain': 'Text content\n'
-        }
+        'text/plain': 'Text content\n'
     }
 
 def test_html():

--- a/redmail/test/email/test_template.py
+++ b/redmail/test/email/test_template.py
@@ -38,11 +38,13 @@ def test_template(tmpdir):
         body_params={"friend": "Jack", 'project_name': 'RedMail'}
     )
     
-    assert "multipart/alternative" == msg.get_content_type()
+    assert "multipart/mixed" == msg.get_content_type()
 
-    #text = remove_extra_lines(msg.get_payload()[0].get_payload())
-    text = remove_email_extra(msg.get_payload()[0].get_payload())
-    html = remove_email_extra(msg.get_payload()[1].get_payload())
+    alternative = msg.get_payload()[0]
+    text_part, html_part = alternative.get_payload()
+
+    text = remove_email_extra(text_part.get_payload())
+    html = remove_email_extra(html_part.get_payload())
 
     assert expected_html == html
     assert expected_text == text

--- a/redmail/test/helpers/convert.py
+++ b/redmail/test/helpers/convert.py
@@ -1,4 +1,5 @@
 
+from collections import Counter
 import re
 
 def remove_extra_lines(s:str):
@@ -8,3 +9,22 @@ def remove_extra_lines(s:str):
 def remove_email_extra(s:str):
     s = remove_extra_lines(s)
     return s.replace("=20", "").replace('"3D', "").replace("=\n", "")
+
+def payloads_to_dict(*parts):
+    data = {}
+    for part in parts:
+
+        payload = part.get_payload()
+        key = part.get_content_type()
+        if key in data:
+            new_key = key
+            n = 0
+            while new_key in data:
+                n += 1
+                new_key = key + f"_{n}"
+            key = new_key
+        if isinstance(payload, str):
+            data[key] = payload
+        else:
+            data[key] = payloads_to_dict(*payload)
+    return data

--- a/redmail/test/helpers/convert.py
+++ b/redmail/test/helpers/convert.py
@@ -10,6 +10,9 @@ def remove_email_extra(s:str):
     s = remove_extra_lines(s)
     return s.replace("=20", "").replace('"3D', "").replace("=\n", "")
 
+def remove_email_content_id(s:str, repl="<ID>"):
+    return re.sub(r"(?<================)[0-9]+(?===)", repl, s)
+
 def payloads_to_dict(*parts):
     data = {}
     for part in parts:
@@ -25,6 +28,9 @@ def payloads_to_dict(*parts):
             key = new_key
         if isinstance(payload, str):
             data[key] = payload
+        elif payload is None:
+            # Most likely empty message
+            pass
         else:
             data[key] = payloads_to_dict(*payload)
     return data

--- a/redmail/test/log/test_handler.py
+++ b/redmail/test/log/test_handler.py
@@ -30,14 +30,12 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "A log record",
-                #'Content-Transfer-Encoding': '7bit',
-                'Content-Type': 'multipart/mixed',
+                'Content-Transfer-Encoding': '7bit',
+                'Content-Type': 'text/plain; charset="utf-8"',
                 'MIME-Version': '1.0',
             },
             {
-                'multipart/mixed': {
-                    'text/plain': 'a message\n'
-                }
+                'text/plain': 'a message\n'
             },
             id="Minimal",
         ),
@@ -54,14 +52,12 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "A log record",
-                #'Content-Transfer-Encoding': '7bit',
-                'Content-Type': 'multipart/mixed',
+                'Content-Transfer-Encoding': '7bit',
+                'Content-Type': 'text/plain; charset="utf-8"',
                 'MIME-Version': '1.0',
             },
             {
-                'multipart/mixed': {
-                    'text/plain': 'Log Record: \n_test: INFO: a message\n'
-                }
+                'text/plain': 'Log Record: \n_test: INFO: a message\n'
             },
             id="Custom message (msg)",
         ),
@@ -78,14 +74,12 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "A log record",
-                #'Content-Transfer-Encoding': '7bit',
-                'Content-Type': 'multipart/mixed',
+                'Content-Transfer-Encoding': '7bit',
+                'Content-Type': 'text/plain; charset="utf-8"',
                 'MIME-Version': '1.0',
             },
             {
-                'multipart/mixed': {
-                    'text/plain': 'Log Record: \na message\n'
-                }
+                'text/plain': 'Log Record: \na message\n'
             },
             id="Custom message (record)",
         ),
@@ -100,14 +94,12 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "Log: _test - INFO",
-                #'Content-Transfer-Encoding': '7bit',
-                'Content-Type': 'multipart/mixed',
+                'Content-Transfer-Encoding': '7bit',
+                'Content-Type': 'text/plain; charset="utf-8"',
                 'MIME-Version': '1.0',
             },
             {
-                'multipart/mixed': {
-                    'text/plain': 'a message\n'
-                }
+                'text/plain': 'a message\n'
             },
             id="Sender with fomatted subject",
         ),

--- a/redmail/test/log/test_handler_multi.py
+++ b/redmail/test/log/test_handler_multi.py
@@ -4,6 +4,8 @@ from redmail import EmailSender
 from redmail import MultiEmailHandler
 import logging
 
+from convert import payloads_to_dict
+
 def _create_dummy_send(messages:list):
     def _dummy_send(msg):
         messages.append(msg)
@@ -28,11 +30,15 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "A log record",
-                'Content-Transfer-Encoding': '7bit',
-                'Content-Type': 'text/plain; charset="utf-8"',
+                #'Content-Transfer-Encoding': '7bit',
+                'Content-Type': 'multipart/mixed',
                 'MIME-Version': '1.0',
             },
-            'Log Recods:\na message\n',
+            {
+                'multipart/mixed': {
+                    'text/plain': 'Log Recods:\na message\n'
+                }
+            },
             id="Minimal",
         ),
         pytest.param(
@@ -48,11 +54,15 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "A log record",
-                'Content-Transfer-Encoding': '7bit',
-                'Content-Type': 'text/plain; charset="utf-8"',
+                #'Content-Transfer-Encoding': '7bit',
+                'Content-Type': 'multipart/mixed',
                 'MIME-Version': '1.0',
             },
-            'The records: \nLog: _test - INFO - a message\n',
+            {
+                'multipart/mixed': {
+                    'text/plain': 'The records: \nLog: _test - INFO - a message\n'
+                }
+            },
             id="Custom message (msgs)",
         ),
         pytest.param(
@@ -68,11 +78,15 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "A log record",
-                'Content-Transfer-Encoding': '7bit',
-                'Content-Type': 'text/plain; charset="utf-8"',
+                #'Content-Transfer-Encoding': '7bit',
+                'Content-Type': 'multipart/mixed',
                 'MIME-Version': '1.0',
             },
-            'The records: \nLog: INFO - a message\n',
+            {
+                'multipart/mixed': {
+                    'text/plain': 'The records: \nLog: INFO - a message\n',
+                }
+            },
             id="Custom message (records)",
         ),
         pytest.param(
@@ -86,11 +100,15 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "Logs: INFO - INFO",
-                'Content-Transfer-Encoding': '7bit',
-                'Content-Type': 'text/plain; charset="utf-8"',
+                #'Content-Transfer-Encoding': '7bit',
+                'Content-Type': 'multipart/mixed',
                 'MIME-Version': '1.0',
             },
-            'Log Recods:\na message\n',
+            {
+                'multipart/mixed': {
+                    'text/plain': 'Log Recods:\na message\n',
+                }
+            },
             id="Sender with fomatted subject",
         ),
         pytest.param(
@@ -106,9 +124,15 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "A log record",
-                'Content-Type': 'multipart/alternative',
+                'Content-Type': 'multipart/mixed',
             },
-            ["<h1>The records:</h1><p>Log: _test - INFO - a message</p>\n"],
+            {
+                'multipart/mixed': {
+                    'multipart/alternative': {
+                        'text/html': "<h1>The records:</h1><p>Log: _test - INFO - a message</p>\n",
+                    }
+                }
+            },
             id="Custom message (HTML, msgs)",
         ),
         pytest.param(
@@ -124,9 +148,15 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "A log record",
-                'Content-Type': 'multipart/alternative',
+                'Content-Type': 'multipart/mixed',
             },
-            ["<h1>The records:</h1><p>Log: INFO - a message</p>\n"],
+            {
+                'multipart/mixed': {
+                    'multipart/alternative': {
+                        'text/html': "<h1>The records:</h1><p>Log: INFO - a message</p>\n",
+                    }
+                }
+            },
             id="Custom message (HTML, records)",
         ),
     ]
@@ -152,12 +182,8 @@ def test_emit(logger, kwargs, exp_headers, exp_payload):
 
     assert headers == exp_headers
 
-    if isinstance(payload, str):
-        assert payload == exp_payload
-    else:
-        # HTML (and text) of payloads
-        payloads = [pl.get_payload() for pl in payload]
-        assert payloads == exp_payload
+    structure = payloads_to_dict(msg)
+    assert structure == exp_payload
 
 
 def test_flush_multiple(logger):
@@ -181,18 +207,19 @@ def test_flush_multiple(logger):
     assert len(msgs) == 1
     msg = msgs[0]
     headers = dict(msg.items())
-    payload = msg.get_payload()
+    payload = msg.get_payload()[0]
+    text = payload.get_payload()
 
     assert headers == {
         "from": "None",
         "to": "he@example.com, she@example.com",
         "subject": "Logs: DEBUG - INFO",
-        'Content-Transfer-Encoding': '7bit',
-        'Content-Type': 'text/plain; charset="utf-8"',
+        #'Content-Transfer-Encoding': '7bit',
+        'Content-Type': 'multipart/mixed',
         'MIME-Version': '1.0',
     }
 
-    assert payload == "Records: \nINFO - an info\nDEBUG - a debug\n"
+    assert text == "Records: \nINFO - an info\nDEBUG - a debug\n"
 
 def test_flush_none():
     msgs = []
@@ -213,15 +240,16 @@ def test_flush_none():
     assert len(msgs) == 1
     msg = msgs[0]
     headers = dict(msg.items())
-    payload = msg.get_payload()
+    payload = msg.get_payload()[0]
+    text = payload.get_payload()
 
     assert headers == {
         "from": "None",
         "to": "he@example.com, she@example.com",
         "subject": "Logs: NOTSET - NOTSET",
-        'Content-Transfer-Encoding': '7bit',
-        'Content-Type': 'text/plain; charset="utf-8"',
+        #'Content-Transfer-Encoding': '7bit',
+        'Content-Type': 'multipart/mixed',
         'MIME-Version': '1.0',
     }
 
-    assert payload == "Records: \n"
+    assert text == "Records: \n"

--- a/redmail/test/log/test_handler_multi.py
+++ b/redmail/test/log/test_handler_multi.py
@@ -30,14 +30,12 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "A log record",
-                #'Content-Transfer-Encoding': '7bit',
-                'Content-Type': 'multipart/mixed',
+                'Content-Transfer-Encoding': '7bit',
+                'Content-Type': 'text/plain; charset="utf-8"',
                 'MIME-Version': '1.0',
             },
             {
-                'multipart/mixed': {
-                    'text/plain': 'Log Recods:\na message\n'
-                }
+                'text/plain': 'Log Recods:\na message\n'
             },
             id="Minimal",
         ),
@@ -54,14 +52,12 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "A log record",
-                #'Content-Transfer-Encoding': '7bit',
-                'Content-Type': 'multipart/mixed',
+                'Content-Transfer-Encoding': '7bit',
+                'Content-Type': 'text/plain; charset="utf-8"',
                 'MIME-Version': '1.0',
             },
             {
-                'multipart/mixed': {
-                    'text/plain': 'The records: \nLog: _test - INFO - a message\n'
-                }
+                'text/plain': 'The records: \nLog: _test - INFO - a message\n'
             },
             id="Custom message (msgs)",
         ),
@@ -78,14 +74,12 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "A log record",
-                #'Content-Transfer-Encoding': '7bit',
-                'Content-Type': 'multipart/mixed',
+                'Content-Transfer-Encoding': '7bit',
+                'Content-Type': 'text/plain; charset="utf-8"',
                 'MIME-Version': '1.0',
             },
             {
-                'multipart/mixed': {
-                    'text/plain': 'The records: \nLog: INFO - a message\n',
-                }
+                'text/plain': 'The records: \nLog: INFO - a message\n',
             },
             id="Custom message (records)",
         ),
@@ -100,14 +94,12 @@ def test_default_body():
                 "from": "me@example.com",
                 "to": "he@example.com, she@example.com",
                 "subject": "Logs: INFO - INFO",
-                #'Content-Transfer-Encoding': '7bit',
-                'Content-Type': 'multipart/mixed',
+                'Content-Transfer-Encoding': '7bit',
+                'Content-Type': 'text/plain; charset="utf-8"',
                 'MIME-Version': '1.0',
             },
             {
-                'multipart/mixed': {
-                    'text/plain': 'Log Recods:\na message\n',
-                }
+                'text/plain': 'Log Recods:\na message\n',
             },
             id="Sender with fomatted subject",
         ),
@@ -207,15 +199,14 @@ def test_flush_multiple(logger):
     assert len(msgs) == 1
     msg = msgs[0]
     headers = dict(msg.items())
-    payload = msg.get_payload()[0]
-    text = payload.get_payload()
+    text = msg.get_payload()
 
     assert headers == {
         "from": "None",
         "to": "he@example.com, she@example.com",
         "subject": "Logs: DEBUG - INFO",
-        #'Content-Transfer-Encoding': '7bit',
-        'Content-Type': 'multipart/mixed',
+        'Content-Transfer-Encoding': '7bit',
+        'Content-Type': 'text/plain; charset="utf-8"',
         'MIME-Version': '1.0',
     }
 
@@ -240,15 +231,14 @@ def test_flush_none():
     assert len(msgs) == 1
     msg = msgs[0]
     headers = dict(msg.items())
-    payload = msg.get_payload()[0]
-    text = payload.get_payload()
+    text = msg.get_payload()
 
     assert headers == {
         "from": "None",
         "to": "he@example.com, she@example.com",
         "subject": "Logs: NOTSET - NOTSET",
-        #'Content-Transfer-Encoding': '7bit',
-        'Content-Type': 'multipart/mixed',
+        'Content-Transfer-Encoding': '7bit',
+        'Content-Type': 'text/plain; charset="utf-8"',
         'MIME-Version': '1.0',
     }
 


### PR DESCRIPTION
This PR changes the structure of the email (in terms of content-types). It should not affect the content (attachments, inline images etc.) but it should fix rendering issues with different email providers.

## If only text
- multipart/mixed
    - text/plain

## If only HTML
- multipart/mixed
    - multipart/alternative
        - text/html

## If only attachment
- multipart/mixed
    - application/octet-stream

## If text and HTML
- multipart/mixed
    - multipart/alternative
        - text/plain
        - text/html

## If text and HTML and embedded image, and attachment
- multipart/mixed
    - multipart/alternative
        - text/plain
        - multipart/related
            - text/html
            - image/jpg
    - application/octet-stream

