### PR TITLE
docs: add copy clipboard button to code blocks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx_book_theme',
     'sphinx.ext.extlinks',
+    'sphinx_copybutton',
 ]
 rst_prolog = """
 .. include:: <s5defs.txt>

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,4 @@
 sphinx >= 1.7.5
 pydata-sphinx-theme
 sphinx_book_theme
+sphinx-copybutton


### PR DESCRIPTION
A handy extension for copying the code blocks.