### PR TITLE
FIX: Allow calling sender.close() multiple times

### DIFF
--- a/docs/tutorials/sending.rst
+++ b/docs/tutorials/sending.rst
@@ -13,7 +13,7 @@ is configured. At minimum, sending an email requires:
 
 .. code-block:: python
 
-    from email import EmailSender
+    from redmail import EmailSender
     email = EmailSender(host='localhost', port=0)
 
     email.send(

--- a/redmail/email/sender.py
+++ b/redmail/email/sender.py
@@ -440,8 +440,9 @@ class EmailSender:
 
     def close(self):
         "Close (quit) the connection"
-        self.connection.quit()
-        self.connection = None
+        if self.connection:
+            self.connection.quit()
+            self.connection = None
 
     def get_server(self) -> smtplib.SMTP:
         "Connect and get the SMTP Server"


### PR DESCRIPTION
Fixes an incorrect import in the tutorial section of the documentation