### PR TITLE
Fix example with wrong key in Embedding Image with dict format

### DIFF
--- a/docs/tutorials/embed/image.rst
+++ b/docs/tutorials/embed/image.rst
@@ -89,7 +89,7 @@ You may also pass the image as bytes:
     data = 'iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=='
     data_as_bytes = base64.b64decode(data_as_base64)
 
-    gmail.send(
+    email.send(
         subject='An image',
         receivers=['first.last@example.com'],
         html="""
@@ -122,7 +122,7 @@ You may also include images using the dict format:
     data = 'iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=='
     data_as_bytes = base64.b64decode(data_as_base64)
 
-    gmail.send(
+    email.send(
         subject='An image',
         receivers=['first.last@example.com'],
         html="""

--- a/docs/tutorials/embed/image.rst
+++ b/docs/tutorials/embed/image.rst
@@ -131,7 +131,7 @@ You may also include images using the dict format:
         """,
         body_images={
             'myimage': { 
-                'myimage': data_as_bytes,
+                'content': data_as_bytes,
                 'subtype': 'png'
             }
         }


### PR DESCRIPTION
In the docs on the page [Embedding Image with dict format](https://red-mail.readthedocs.io/en/stable/tutorials/embed/image.html#embedding-images) the following example is given:

```py
gmail.send(
    subject='An image',
    receivers=['first.last@example.com'],
    html="""
        <h1>This is an image:</h1>
        {{ myimage }}
    """,
    body_images={
        'myimage': {
            'myimage': data_as_bytes,
            'subtype': 'png'
        }
    }
)
```

Yet the dict expects `content` instead of `myimages` as seen in the tests

https://github.com/Miksus/red-mail/blob/cf0396ca0d4bf40182be6bb289afc2bb1ecfef6b/redmail/test/email/test_inline_media.py#L89-L92